### PR TITLE
A slew of small fixes on the query-execution openAPI spec

### DIFF
--- a/api-reference/crud/crud-openapi.json
+++ b/api-reference/crud/crud-openapi.json
@@ -26,7 +26,7 @@
             "required": true
           },
           {
-            "in": "path",
+            "in": "query",
             "name": "api_key",
             "schema": {
               "type": "string"
@@ -236,7 +236,7 @@
             "required": true
           },
           {
-            "in": "path",
+            "in": "query",
             "name": "api_key",
             "schema": {
               "type": "string"
@@ -341,7 +341,7 @@
             "required": true
           },
           {
-            "in": "path",
+            "in": "query",
             "name": "api_key",
             "schema": {
               "type": "string"
@@ -445,7 +445,7 @@
             "required": true
           },
           {
-            "in": "path",
+            "in": "query",
             "name": "api_key",
             "schema": {
               "type": "string"
@@ -549,7 +549,7 @@
             "required": true
           },
           {
-            "in": "path",
+            "in": "query",
             "name": "api_key",
             "schema": {
               "type": "string"
@@ -663,7 +663,7 @@
             "required": true
           },
           {
-            "in": "path",
+            "in": "query",
             "name": "api_key",
             "schema": {
               "type": "string"

--- a/api-reference/crud/crud-openapi.json
+++ b/api-reference/crud/crud-openapi.json
@@ -1,8 +1,8 @@
 {
   "openapi": "3.0.1",
   "info": {
-    "title": "OpenAPI for CRUD API",
-    "description": "API for create, read, update, and delete operations on Dune queries.",
+    "title": "OpenAPI for Query CRUD API",
+    "description": "API for Create, Read, Update, and Delete operations on Dune queries.",
     "version": "1.0.0"
   },
   "servers": [
@@ -22,8 +22,17 @@
             "schema": {
               "type": "string"
             },
-            "description": "API Key for accessing this service",
+            "description": "API Key for the service",
             "required": true
+          },
+          {
+            "in": "path",
+            "name": "api_key",
+            "schema": {
+              "type": "string"
+            },
+            "description": "API Key for the service, alternative to using the HTTP header X-DUNE-API-KEY.",
+            "required": false
           },
           {
             "in": "path",
@@ -108,7 +117,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "API Key for accessing this service",
+            "description": "API Key for the service",
             "required": true
           },
           {
@@ -223,8 +232,17 @@
             "schema": {
               "type": "string"
             },
-            "description": "API Key for accessing this service",
+            "description": "API Key for the service",
             "required": true
+          },
+          {
+            "in": "path",
+            "name": "api_key",
+            "schema": {
+              "type": "string"
+            },
+            "description": "API Key for the service, alternative to using the HTTP header X-DUNE-API-KEY.",
+            "required": false
           }
         ],
         "requestBody": {
@@ -319,8 +337,17 @@
             "schema": {
               "type": "string"
             },
-            "description": "API Key for accessing this service",
+            "description": "API Key for the service",
             "required": true
+          },
+          {
+            "in": "path",
+            "name": "api_key",
+            "schema": {
+              "type": "string"
+            },
+            "description": "API Key for the service, alternative to using the HTTP header X-DUNE-API-KEY.",
+            "required": false
           },
           {
             "in": "path",
@@ -414,8 +441,17 @@
             "schema": {
               "type": "string"
             },
-            "description": "API Key for accessing this service",
+            "description": "API Key for the service",
             "required": true
+          },
+          {
+            "in": "path",
+            "name": "api_key",
+            "schema": {
+              "type": "string"
+            },
+            "description": "API Key for the service, alternative to using the HTTP header X-DUNE-API-KEY.",
+            "required": false
           },
           {
             "in": "path",
@@ -509,8 +545,17 @@
             "schema": {
               "type": "string"
             },
-            "description": "API Key for accessing this service",
+            "description": "API Key for the service",
             "required": true
+          },
+          {
+            "in": "path",
+            "name": "api_key",
+            "schema": {
+              "type": "string"
+            },
+            "description": "API Key for the service, alternative to using the HTTP header X-DUNE-API-KEY.",
+            "required": false
           },
           {
             "in": "path",
@@ -614,8 +659,17 @@
             "schema": {
               "type": "string"
             },
-            "description": "API Key for accessing this service",
+            "description": "API Key for the service",
             "required": true
+          },
+          {
+            "in": "path",
+            "name": "api_key",
+            "schema": {
+              "type": "string"
+            },
+            "description": "API Key for the service, alternative to using the HTTP header X-DUNE-API-KEY.",
+            "required": false
           },
           {
             "in": "path",

--- a/api-reference/overview/authentication.mdx
+++ b/api-reference/overview/authentication.mdx
@@ -5,7 +5,7 @@ title: Authentication
 The Dune API relies on API keys for authentication. Your API key grants access and determines billing details for private queries, so safeguard it diligently!
 
 ## Generate an API key
-In order to generate a new API key, go to settings -> API -> create new API key. 
+In order to generate a new API key, go to settings -> API -> create new API key.
 
 <Note> 
     - Dune has two types of account: `user` account and `team` account. A team can have many users. A user can join many teams. 

--- a/api-reference/overview/faq.mdx
+++ b/api-reference/overview/faq.mdx
@@ -54,10 +54,6 @@ Yes!
     
 The results storage period can be found on the API response on the “expires_at” field in the execution status and results body.
 
-#### How much data can I retrieve in a single API result call?
-    
-There is currently a ~1GB limit. The API does not currently return an explicit error upon hitting this limit but will instead fail (timeout) when attempting to retrieve the results.
-
 #### How do I import Dune data into a google sheet? 
 
 Use "Import Data" to import your CSV results into a google sheet using "api_key" as a param. (We advise against doing this any public document where your API key can be viewed and compromised.)

--- a/api-reference/overview/introduction.mdx
+++ b/api-reference/overview/introduction.mdx
@@ -15,7 +15,7 @@ Dune's four core API offerings can be found below:
     Execute queries and get results in JSON or CSV form
   </Card>
   <Card
-    title="CRUD (Create, Read, Update, Delete)"
+    title="Query CRUD (Create, Read, Update, Delete)"
     icon="floppy-disk"
     href="/api-reference/crud/endpoint/create"
   >

--- a/api-reference/overview/pagination.mdx
+++ b/api-reference/overview/pagination.mdx
@@ -407,17 +407,17 @@ If you pass in an invalid `offset` parameter value, you will get an empty result
 </Accordion>
 
 <Tip>
-**Data Returned Limit **
+**Data Returned Limit**
 When using pagination, our intention is to use sizes that work well on mobile, with lower data and ram consumption. For this, and to avoid more work on the developer, when the client specifies a very large limit value (for example 500000 rows), instead of returning an error, the server will override this limit to a lower, safer value (for example 30000 rows) and *will always provide* the correct next `offset` and `limit` value to use on the next paginated requests. The exact maximum limit value is subject to change.
 
 
-**Data Size Limit **
+**Data Size Limit**
 
 Dune internally has a maximum query result size limit (which currently is 8GB, but subject to increase in the future). If your query yields more than 8GB of data, the result will be truncated in storage. In such cases, pulling the result data (using pagination) but without specifying `allow_partial_results` set to true will trigger an error message: "error": "Partial Result, please request with 'allows_partial_results=true'". If you wish to retrieve partial results, you can pass the parameter `allow_partial_results=true`. But please make sure you indeed want to fetch the truncated result.
 
 So what? Related to pagination, this means that 
 - For query results under 8GB, use the API as normal.
 - When your query results exceed 8GB, in addition to `limit` and `offset` parameters in order to read the partial result (the first 8GB of data), set `allow_partial_results=true`
-- You can use the (Get Status API)[https://dune.mintlify.app/api-reference/query-api/endpoint/get-execution-status] to check the size of your result, `result.result_set_size`
+- You can use the [Get Status API](https://dune.mintlify.app/api-reference/query-api/endpoint/get-execution-status) to check the size of your result, `result.result_set_size`
 
 </Tip>

--- a/api-reference/overview/pagination.mdx
+++ b/api-reference/overview/pagination.mdx
@@ -1,12 +1,12 @@
 ---
 title: Pagination
 ---
-All get results endpoints, including [get execution results](../query-api/endpoint/get-execution-result), [get execution results csv](../query-api/endpoint/get-execution-result-csv), [get query results](../query-api/endpoint/get-query-result), [get query results csv](../query-api/endpoint/get-query-result-csv), support pagination for efficient data retrieval. Pagination divides large datasets into smaller, manageable chunks, preventing overload and ensuring smooth performance. This allows users to navigate through the data easily, avoiding limit errors and streamlining their data fetching experience.
+All API endpoints to read query results, including [get execution results](../query-api/endpoint/get-execution-result), [get execution results csv](../query-api/endpoint/get-execution-result-csv), [get query results](../query-api/endpoint/get-query-result), [get query results csv](../query-api/endpoint/get-query-result-csv), support pagination for efficient data retrieval. Pagination divides large datasets into smaller, manageable chunks, preventing overload and ensuring smooth performance. This allows users to navigate through the data easily, avoiding limit errors and streamlining their data fetching experience.
 
 To paginate through results:
-1. Specify the `limit` parameter to determine the number of results per page.
-2. Use the `offset` parameter to indicate the starting point for retrieving results.
-3. If you are fetching JSON response, check for the fields `next_offset` and `next_uri` in the response body to fetch the next page, if available. If you are fetching CSV response, check the response headers for `X-Dune-Next-Offset` and `X-Dune-Next-Uri` to fetch the next page, if available.
+1. Specify the `limit` parameter to determine the number of results you want to retrieve. 
+2. Use the `offset` parameter to indicate the starting offset point for retrieving results, default value is 0 for the first row.
+3. If you are fetching JSON response, check for the fields `next_offset` and `next_uri` in the response body to fetch the next page, if available. If you are fetching CSV response, check the response headers for `X-Dune-Next-Offset` and `X-Dune-Next-Uri` to fetch the next page, if available. Always follow the provided offset or uri, the server is allowed to override the provided limit if it is too large (see section on Data Returned Limit)
 
 
 ### Pagination Parameters
@@ -25,7 +25,7 @@ To paginate through results:
     <Tabs>
         <Tab title="cURL">
         ```bash 
-        curl -X GET 'https://api.dune.com/api/v1/query/3426636/results?limit=5&offset=0' -H 'x-dune-api-key: {{api_key}}' 
+        curl -X GET 'https://api.dune.com/api/v1/query/3426636/results?limit=1000' -H 'x-dune-api-key: {{api_key}}' 
         ```
         </Tab>
         
@@ -45,7 +45,7 @@ To paginate through results:
 
         headers = {"X-DUNE-API-KEY": "<x-dune-api-key>"}
 
-        params = {"limit": 5, "offset": 0}  # Define limit and offset parameters
+        params = {"limit": 1000, "offset": 0}  # Define limit and offset parameters
 
         response = requests.request("GET", url, headers=headers, params=params)
 
@@ -64,7 +64,7 @@ To paginate through results:
             }
         };
 
-        const queryParams = new URLSearchParams({limit: 5, offset: 0});  // Define limit and offset parameters
+        const queryParams = new URLSearchParams({limit: 1000, offset: 0});  // Define limit and offset parameters
         const url = `https://api.dune.com/api/v1/query/{query_id}/results?${queryParams}`;
 
         fetch(url, options)
@@ -91,8 +91,7 @@ To paginate through results:
 
             // Create query parameters
             params := url.Values{}
-            params.Set("limit", "5")
-            params.Set("offset", "0")
+            params.Set("limit", "1000")
 
             // Add parameters to URL
             fullURL := fmt.Sprintf("%s?%s", url, params.Encode())
@@ -120,7 +119,7 @@ To paginate through results:
 
         $url = "https://api.dune.com/api/v1/query/{query_id}/results";
         $queryParams = http_build_query([
-            'limit' => 5,
+            'limit' => 1000,
             'offset' => 0
         ]);
         $url .= '?' . $queryParams;
@@ -176,7 +175,7 @@ To paginate through results:
 
 ### Pagination in Response
 
-The following fields in the repsonse body are related to pagination and can be utilized when doing paginated get results request. If they are available, you can use them to paginate the next page. If they are not avaialble, that means there is no more results to be fetched.
+The following fields in the repsonse body are related to pagination and can be utilized when doing paginated get results request. If they are available, you can use them to paginate the next page. If they are not available, that means there are no more results to be fetched.
 
 <Tabs>
     <Tab title="JSON response endpoints">
@@ -186,7 +185,7 @@ The following fields in the repsonse body are related to pagination and can be u
 
         **`next_uri`**
         - Type: String (URL)
-        - Description: Specifies the URI to retrieve the next page of results, if available.
+        - Description: Specifies the complete URI to retrieve the next page of results, if available.
     </Tab>
     <Tab title="CSV response endpoints">
         **`x-dune-next-offset`**
@@ -195,12 +194,12 @@ The following fields in the repsonse body are related to pagination and can be u
 
         **`x-dune-next-uri`**
         - Type: String (URL)
-        - Description: Specifies the URI to retrieve the next page of results, if available.
+        - Description: Specifies the complete URI to retrieve the next page of results, if available.
     </Tab>
 </Tabs>
 
 <Note>
-If you pass in an invalid `limit` and `offset` parameter values, you will get an empty result set. For example, if there are only 10 rows of result data, and you pass in `offset=11`, you will **not** receive an error, but rather an empty result with metadata like this.
+If you pass in an invalid `offset` parameter value, you will get an empty result set. For example, if there are only 25 rows of result data, and you pass in `offset=30`, you will **not** receive an error, but rather an empty result with metadata like this. Note the response field `result.total_row_count`, indicating this result has only 25 rows.
 <Accordion title="Example empty response">
     ```json
         {
@@ -408,12 +407,17 @@ If you pass in an invalid `limit` and `offset` parameter values, you will get an
 </Accordion>
 
 <Tip>
-**Data Return Limit**
+**Data Returned Limit **
+When using pagination, our intention is to use sizes that work well on mobile, with lower data and ram consumption. For this, and to avoid more work on the developer, when the client specifies a very large limit value (for example 500000 rows), instead of returning an error, the server will override this limit to a lower, safer value (for example 30000 rows) and *will always provide* the correct next `offset` and `limit` value to use on the next paginated requests. The exact maximum limit value is subject to change.
 
-Dune imposes a 1GB data limit on query results for each query execution. If your query yields more than 1GB of data, the result will be truncated in storage. In such cases, pulling the result data with `allow_partial_results` set to false (the default) will trigger an error message: "error": "Partial Result, please request with 'allows_partial_results=true'". If you wish to retrieve partial results, you can pass the parameter `allow_partial_results=true`. But please make sure you indeed want to fetch the truncated result.
+
+**Data Size Limit **
+
+Dune internally has a maximum query result size limit (which currently is 8GB, but subject to increase in the future). If your query yields more than 8GB of data, the result will be truncated in storage. In such cases, pulling the result data (using pagination) but without specifying `allow_partial_results` set to true will trigger an error message: "error": "Partial Result, please request with 'allows_partial_results=true'". If you wish to retrieve partial results, you can pass the parameter `allow_partial_results=true`. But please make sure you indeed want to fetch the truncated result.
 
 So what? Related to pagination, this means that 
-- When query results exceed 1GB, set `allow_partial_results=true` to in addition to `limit` and `offset` parameters in order to pull partial result.
-- For query results under 1GB, pagination with `limit` and `offset` can be used as usual.
+- For query results under 8GB, use the API as normal.
+- When your query results exceed 8GB, in addition to `limit` and `offset` parameters in order to read the partial result (the first 8GB of data), set `allow_partial_results=true`
+- You can use the (Get Status API)[https://dune.mintlify.app/api-reference/query-api/endpoint/get-execution-status] to check the size of your result, `result.result_set_size`
 
 </Tip>

--- a/api-reference/overview/pagination.mdx
+++ b/api-reference/overview/pagination.mdx
@@ -4,7 +4,7 @@ title: Pagination
 All API endpoints to read query results, including [get execution results](../query-api/endpoint/get-execution-result), [get execution results csv](../query-api/endpoint/get-execution-result-csv), [get query results](../query-api/endpoint/get-query-result), [get query results csv](../query-api/endpoint/get-query-result-csv), support pagination for efficient data retrieval. Pagination divides large datasets into smaller, manageable chunks, preventing overload and ensuring smooth performance. This allows users to navigate through the data easily, avoiding limit errors and streamlining their data fetching experience.
 
 To paginate through results:
-1. Specify the `limit` parameter to determine the number of results you want to retrieve. 
+1. Specify the `limit` parameter to determine the number of results you want to retrieve.
 2. Use the `offset` parameter to indicate the starting offset point for retrieving results, default value is 0 for the first row.
 3. If you are fetching JSON response, check for the fields `next_offset` and `next_uri` in the response body to fetch the next page, if available. If you are fetching CSV response, check the response headers for `X-Dune-Next-Offset` and `X-Dune-Next-Uri` to fetch the next page, if available. Always follow the provided offset or uri, the server is allowed to override the provided limit if it is too large (see section on Data Returned Limit)
 
@@ -24,11 +24,11 @@ To paginate through results:
 <Accordion title="Example paginated request">
     <Tabs>
         <Tab title="cURL">
-        ```bash 
-        curl -X GET 'https://api.dune.com/api/v1/query/3426636/results?limit=1000' -H 'x-dune-api-key: {{api_key}}' 
+        ```bash
+        curl -X GET 'https://api.dune.com/api/v1/query/3426636/results?limit=1000' -H 'x-dune-api-key: {{api_key}}'
         ```
         </Tab>
-        
+
         <Tab title="Python SDK">
         ```python Python SDK
 
@@ -55,7 +55,7 @@ To paginate through results:
         </Tab>
 
         <Tab title="Javascript">
-        ```javascript 
+        ```javascript
 
         const options = {
             method: 'GET',
@@ -112,7 +112,7 @@ To paginate through results:
         </Tab>
 
         <Tab title="PHP">
-        ```php 
+        ```php
         <?php
 
         $curl = curl_init();
@@ -226,7 +226,7 @@ If you pass in an invalid `offset` parameter value, you will get an empty result
                 "execution_time_millis": 341
                 }
             }
-        }    
+        }
     ```
 </Accordion>
 </Note>
@@ -400,7 +400,7 @@ If you pass in an invalid `offset` parameter value, you will get an empty result
                     "execution_time_millis": 1336
                 }
             },
-            "next_uri": "https://api.dune.com/api/v1/execution/01HPFJ7VSFXPTA8WPMDKBXE167/results?limit=5&offset=5",
+            "next_uri": "https://api.dune.com/api/v1/execution/01HPFJ7VSFXPTA8WPMDKBXE167/results?limit=1000&offset=5",
             "next_offset": 5
         }
     ```
@@ -408,6 +408,7 @@ If you pass in an invalid `offset` parameter value, you will get an empty result
 
 <Tip>
 **Data Returned Limit**
+
 When using pagination, our intention is to use sizes that work well on mobile, with lower data and ram consumption. For this, and to avoid more work on the developer, when the client specifies a very large limit value (for example 500000 rows), instead of returning an error, the server will override this limit to a lower, safer value (for example 30000 rows) and *will always provide* the correct next `offset` and `limit` value to use on the next paginated requests. The exact maximum limit value is subject to change.
 
 
@@ -415,7 +416,7 @@ When using pagination, our intention is to use sizes that work well on mobile, w
 
 Dune internally has a maximum query result size limit (which currently is 8GB, but subject to increase in the future). If your query yields more than 8GB of data, the result will be truncated in storage. In such cases, pulling the result data (using pagination) but without specifying `allow_partial_results` set to true will trigger an error message: "error": "Partial Result, please request with 'allows_partial_results=true'". If you wish to retrieve partial results, you can pass the parameter `allow_partial_results=true`. But please make sure you indeed want to fetch the truncated result.
 
-So what? Related to pagination, this means that 
+So what? Related to pagination, this means that
 - For query results under 8GB, use the API as normal.
 - When your query results exceed 8GB, in addition to `limit` and `offset` parameters in order to read the partial result (the first 8GB of data), set `allow_partial_results=true`
 - You can use the [Get Status API](https://dune.mintlify.app/api-reference/query-api/endpoint/get-execution-status) to check the size of your result, `result.result_set_size`

--- a/api-reference/overview/query-parameters.mdx
+++ b/api-reference/overview/query-parameters.mdx
@@ -9,7 +9,18 @@ There are four kinds of parameters you can use in a Dune query (these are not AP
 - date
 - enum (called a list in the UI)
 
-For passing these parameters through the API request body, you can use the following format:
+For passing these parameters through the API request body, you can use the following format for executions:
+
+```json
+{
+"foo": "value",
+"bar":1000, 
+"baz": "2020-12-01T01:20:30Z"
+}
+```
+Where "foo", "bar", and "baz" are three params in a query. If you leave one out, it goes with the default param valiue.
+
+For CRUD operations, you'll need to define the type and more:
 
 ```json
 [

--- a/api-reference/overview/rate-limits.mdx
+++ b/api-reference/overview/rate-limits.mdx
@@ -29,4 +29,4 @@ For example, on the Free plan, you have a low limit of 15 requests per minute an
 
 **Data Return Limit**
 
-Dune imposes a 1GB data limit on query results for each query execution. If your query yields more than 1GB of data, the result will be truncated in storage. In such cases, pulling the result data with `allow_partial_results` set to false (the default) will trigger an error message: "error": "Partial Result, please request with 'allows_partial_results=true'". To retrieve partial results, you must pass the parameter `allow_partial_results=true`.
+Dune internally has a maximum query result size limit (which currently is 8GB, but subject to increase in the future). If your query yields more than 8GB of data, the result will be truncated in storage. In such cases, pulling the result data (using pagination) but without specifying `allow_partial_results` set to true will trigger an error message: "error": "Partial Result, please request with 'allows_partial_results=true'". If you wish to retrieve partial results, you can pass the parameter `allow_partial_results=true`. But please make sure you indeed want to fetch the truncated result.

--- a/api-reference/overview/troubleshooting.mdx
+++ b/api-reference/overview/troubleshooting.mdx
@@ -26,24 +26,6 @@ For specific error code information, please refer to each of the endpoint itself
 ```
 You did not input a valid API key. You can go generate a new key and make sure you save it in a safe place and paste the key over.
 
-#### Result too large 
-```json
-{
-  "execution_id": "01HMF87Y5WW6NQ7VQ35Z691JER",
-  "query_id": 3362169,
-  "state": "QUERY_STATE_FAILED",
-  "submitted_at": "2024-01-18T21:39:41.885699Z",
-  "expires_at": "2024-04-17T21:40:15.146884Z",
-  "execution_started_at": "2024-01-18T21:39:41.905154Z",
-  "execution_ended_at": "2024-01-18T21:40:15.146883Z",
-  "error": {
-    "type": "FAILED_TYPE_RESULT_SIZE_EXCEEDED",
-    "message": "Result is too large and was truncated to 1.0GiB. Set allow_partial_results=true query parameter to get the partial result."
-  }
-}
-```
-The result for the query exceeds the 1GB limit. If you'd like to get partial, truncated result, please set `allow_partial_results` to true. 
-
 
 #### Permission error
 ```json

--- a/api-reference/overview/what-is-execution-id.mdx
+++ b/api-reference/overview/what-is-execution-id.mdx
@@ -8,7 +8,8 @@ Unlike a query ID, which identifies a specific query, an execution ID represents
 
 With an execution ID, you can monitor the execution's status using the [check status](../query-api//endpoint/get-execution-status) endpoint. The status can be one of the following: pending, success, or failure.
 
-If an execution is successful, you can also retrieve its latest result (provided it hasn't expired).
+If an execution is successful, you can get the result using [get result](../query-api/endpoint/get-execution-result). Results are saved and can be retrieved multiple times.
+Results data from an execution are stored with an expiration date of 90 days (subject to change). This is visible on the API response on the “expires_at” field in the execution status and results json body (not on the CSV endpoint).
 
 <Tip>
     Consider saving your execution ID in some cases to retrieve the result later without initiating a new execution.

--- a/api-reference/query-api/endpoint/execute-query.mdx
+++ b/api-reference/query-api/endpoint/execute-query.mdx
@@ -40,9 +40,9 @@ openapi: 'POST /v1/query/{query_id}/execute'
     ```
 </Accordion>
 
-If the query has parameters and you don't add them in your API call, it will just run the default params. You may add query parameters as part of the POST params data.
+If the query has parameters and you don't add them in your API call, it will just run with the default params. You may add query parameters as part of the POST params data.
 
-You can choose to include a `performance` parameter, by default it will use the "medium" performance tier which consumes 10 credits. "large" will use 20 credits and be faster.
+You can choose to include a `performance` parameter, by default it will use the "medium" performance tier which consumes 10 credits. "large" will use 20 credits and are faster.
 
 Returns an execution_id associated with the triggered query execution and the state of the execution.
 

--- a/api-reference/query-api/endpoint/get-execution-result-csv.mdx
+++ b/api-reference/query-api/endpoint/get-execution-result-csv.mdx
@@ -10,9 +10,8 @@ Result returns the status, metadata, and query results (in CSV) from a query exe
 <Info> 
 
 - Results data from an execution are stored with an expiration date of 90 days. This is visible on the API response on the “expires_at” field in the execution status and results json body (not on the CSV endpoint). 
-- There is currently a 1GB limit in how much data a single API result call can return, but there is a chance we reduce this overall or based on varying paid plan types. 
-
-- To paginate query results, please visit the [pagination page](../../overview/pagination) to get more info. 
+- Dune internally has a maximum query result size limit (which currently is 8GB, but subject to increase in the future). If your query yields more than 8GB of data, the result will be truncated in storage. In such cases, pulling the result data (using pagination) but without specifying `allow_partial_results` set to true will trigger an error message: "error": "Partial Result, please request with 'allows_partial_results=true'". If you wish to retrieve partial results, you can pass the parameter `allow_partial_results=true`. But please make sure you indeed want to fetch the truncated result.
+- We recommend reading about [Pagination](../../overview/pagination) to get the most out of the API and handle large results.
 
 </Info>
 

--- a/api-reference/query-api/endpoint/get-execution-result-csv.mdx
+++ b/api-reference/query-api/endpoint/get-execution-result-csv.mdx
@@ -9,8 +9,7 @@ Result returns the status, metadata, and query results (in CSV) from a query exe
 
 <Info> 
 
-- Results data from an execution are currently stored for 90 days. This is visible on the API response on the “expires_at” field in the execution status and results body. 
-
+- Results data from an execution are stored with an expiration date of 90 days. This is visible on the API response on the “expires_at” field in the execution status and results json body (not on the CSV endpoint). 
 - There is currently a 1GB limit in how much data a single API result call can return, but there is a chance we reduce this overall or based on varying paid plan types. 
 
 - To paginate query results, please visit the [pagination page](../../overview/pagination) to get more info. 

--- a/api-reference/query-api/endpoint/get-execution-result.mdx
+++ b/api-reference/query-api/endpoint/get-execution-result.mdx
@@ -10,8 +10,8 @@ Result returns the status, metadata, and query results (in JSON) from a query ex
 
 <Info> 
 - Results data from an execution are stored for 90 days. This is visible on the API response on the “expires_at” field in the execution status and results body. 
-- There is currently a 1GB limit in how much data a single API result call can return, but there is a chance we reduce this overall or based on varying paid plan types. 
-- To paginate query results, please visit the [pagination page](../../overview/pagination) to get more info. 
+- Dune internally has a maximum query result size limit (which currently is 8GB, but subject to increase in the future). If your query yields more than 8GB of data, the result will be truncated in storage. In such cases, pulling the result data (using pagination) but without specifying `allow_partial_results` set to true will trigger an error message: "error": "Partial Result, please request with 'allows_partial_results=true'". If you wish to retrieve partial results, you can pass the parameter `allow_partial_results=true`. But please make sure you indeed want to fetch the truncated result.
+- We recommend reading about [Pagination](../../overview/pagination) to get the most out of the API and handle large results.
 
 </Info>
 

--- a/api-reference/query-api/endpoint/get-query-result-csv.mdx
+++ b/api-reference/query-api/endpoint/get-query-result-csv.mdx
@@ -12,8 +12,8 @@ The query specified must either be public or a query you have ownership of (you 
 <Tip> This endpoint does NOT trigger an execution but does [consume credits through datapoints](https://dune.com/pricing). </Tip>
 
 <Info> 
-- There is currently a 1GB limit in how much data a single API result call can return, but there is a chance we reduce this overall or based on varying paid plan types.
-- To paginate query results, please visit the [pagination page](../../overview/pagination) to get more info. 
+- Dune internally has a maximum query result size limit (which currently is 8GB, but subject to increase in the future). If your query yields more than 8GB of data, the result will be truncated in storage. In such cases, pulling the result data (using pagination) but without specifying `allow_partial_results` set to true will trigger an error message: "error": "Partial Result, please request with 'allows_partial_results=true'". If you wish to retrieve partial results, you can pass the parameter `allow_partial_results=true`. But please make sure you indeed want to fetch the truncated result.
+- We recommend reading about [Pagination](../../overview/pagination) to get the most out of the API and handle large results.
 </Info>
 
 <Accordion title="Execute query and get result in one call">

--- a/api-reference/query-api/endpoint/get-query-result.mdx
+++ b/api-reference/query-api/endpoint/get-query-result.mdx
@@ -12,8 +12,8 @@ The query specified must either be public or a query you have ownership of (you 
 <Tip> This endpoint does NOT trigger an execution but does [consume credits through datapoints](https://dune.com/pricing). </Tip>
 
 <Info> 
-- There is currently a 1GB limit in how much data a single API result call can return, but there is a chance we reduce this overall or based on varying paid plan types.
-- To paginate query results, please visit the [pagination page](../../overview/pagination) to get more info. 
+- Dune internally has a maximum query result size limit (which currently is 8GB, but subject to increase in the future). If your query yields more than 8GB of data, the result will be truncated in storage. In such cases, pulling the result data (using pagination) but without specifying `allow_partial_results` set to true will trigger an error message: "error": "Partial Result, please request with 'allows_partial_results=true'". If you wish to retrieve partial results, you can pass the parameter `allow_partial_results=true`. But please make sure you indeed want to fetch the truncated result.
+- We recommend reading about [Pagination](../../overview/pagination) to get the most out of the API and handle large results.
 </Info>
 
 <Accordion title="Execute query and get result in one call">

--- a/api-reference/query-api/query-openapi.json
+++ b/api-reference/query-api/query-openapi.json
@@ -933,7 +933,7 @@
           "execution_started_at": "2024-01-12T21:34:37.464387Z",
           "execution_ended_at": "2024-01-12T21:34:55.737081Z",
           "next_offset": 5,
-          "next_uri": "https://api.dev.dune.com/api/v1/execution/01HKZSJAW6N2MFVCBHA3R8S64X/results?limit=5&offset=5",
+          "next_uri": "https://api.dev.dune.com/api/v1/execution/01HKZSJAW6N2MFVCBHA3R8S64X/results?limit=1000&offset=5",
           "result": {
             "metadata": {
               "column_names": [
@@ -1048,7 +1048,7 @@
           "next_uri": {
             "type": "string",
             "description": "URI that can be used to fetch the next page of results.",
-            "example": "https://api.dev.dune.com/api/v1/execution/01HKZSJAW6N2MFVCBHA3R8S64X/results?limit=5&offset=5"
+            "example": "https://api.dev.dune.com/api/v1/execution/01HKZSJAW6N2MFVCBHA3R8S64X/results?limit=1000&offset=5"
           },
           "result": {
             "$ref": "#/components/schemas/QueryResultData"

--- a/api-reference/query-api/query-openapi.json
+++ b/api-reference/query-api/query-openapi.json
@@ -63,7 +63,7 @@
                 "$ref": "#/components/schemas/ParameterObject"
               }
             },
-            "description": "SQL Query parameters in key-value pairs. Each parameter is an object consisting of keys such as 'key', 'type', 'value', and optionally 'enumOptions'. The API allows for partial submission of parameters. For example, if the query expects three parameters and you only pass in two, the third one will automatically use its default value as defined in the API. This feature enables you to parameterize the query execution according to your specific needs while providing sensible defaults for unspecified parameters."
+            "description": "SQL Query parameters in key-value pairs. Each parameter is to be provided in key-value pairs. This enables you to execute a parameterized query with the provided values for your parameter keys. Partial submission of parameters is allowed. For example, if the query expects three parameters and you only pass in two, the third one will automatically use its default value as defined in the Query Parameter Editor page."
           }
         ],
         "responses": {
@@ -380,7 +380,7 @@
                 "$ref": "#/components/schemas/ParameterObject"
               }
             },
-            "description": "SQL Query parameters in key-value pairs. Each parameter is an object consisting of keys such as 'key', 'type', 'value', and optionally 'enumOptions'. The API allows for partial submission of parameters. For example, if the query expects three parameters and you only pass in two, the third one will automatically use its default value as defined in the API. This feature enables you to parameterize the query execution according to your specific needs while providing sensible defaults for unspecified parameters."
+            "description": "SQL Query parameters in key-value pairs. Each parameter is to be provided in key-value pairs. This enables you to execute a parameterized query with the provided values for your parameter keys. Partial submission of parameters is allowed. For example, if the query expects three parameters and you only pass in two, the third one will automatically use its default value as defined in the Query Parameter Editor page."
           },
           {
             "in": "query",
@@ -528,7 +528,7 @@
                 "$ref": "#/components/schemas/ParameterObject"
               }
             },
-            "description": "SQL Query parameters in key-value pairs. Each parameter is an object consisting of keys such as 'key', 'type', 'value', and optionally 'enumOptions'. The API allows for partial submission of parameters. For example, if the query expects three parameters and you only pass in two, the third one will automatically use its default value as defined in the API. This feature enables you to parameterize the query execution according to your specific needs while providing sensible defaults for unspecified parameters."
+            "description": "SQL Query parameters in key-value pairs. Each parameter is to be provided in key-value pairs. This enables you to execute a parameterized query with the provided values for your parameter keys. Partial submission of parameters is allowed. For example, if the query expects three parameters and you only pass in two, the third one will automatically use its default value as defined in the Query Parameter Editor page."
           },
           {
             "in": "query",
@@ -1313,65 +1313,11 @@
       },
       "ParameterObject": {
         "type": "object",
-        "required": ["key"],
-        "description": "SQL Query parameters in key-value pairs. Each parameter is an object consisting of keys such as 'key', 'type', 'value', and optionally 'enumOptions'. The API allows for partial submission of parameters. For example, if the query expects three parameters and you only pass in two, the third one will automatically use its default value as defined in the API. This feature enables you to parameterize the query execution according to your specific needs while providing sensible defaults for unspecified parameters.",
-        "properties": {
-          "key": {
-            "type": "string",
-            "description": "The key name of the parameter."
-          },
-          "description": {
-            "type": "string",
-            "description": "A brief description of the parameter."
-          },
-          "value": {
-            "type": "string",
-            "description": "The default value used by this parameter during execution, format depends on the type."
-          },
-          "values": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            },
-            "description": "An array of string values, used when multiple selections are allowed."
-          },
-          "type": {
-            "type": "string",
-            "enum": ["number", "text", "datetime", "enum"],
-            "description": "The type of the parameter, determines the format of 'value(s)'. 'number': Numeric parameters, the value must be a number (e.g., '20'). 'text': String parameters, value can be any text including hex 0x-prefixed values (e.g., '0xae2fc...'), an empty value defaults to an empty string. 'datetime': Date and time parameters, value must be in 'YYYY-MM-DD hh:mm:ss' format (e.g., '2021-12-31 23:59:59'). 'enum': Parameters with a specific list of values, 'EnumValues' field is mandatory, providing a JSON list of strings representing valid options, the 'value' must be one of these options (e.g., 'Option1')."
-          },
-          "EnumValues": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            },
-            "description": "List of valid options for 'enum' type parameters."
-          },
-          "isMultiselect": {
-            "type": "boolean",
-            "description": "Indicates if multiple selections are allowed for this parameter."
-          },
-          "isFreeformAllowed": {
-            "type": "boolean",
-            "description": "Indicates if freeform input is allowed for this parameter."
-          },
-          "enumFromResults": {
-            "$ref": "#/components/schemas/EnumFromResults"
-          }
-        }
-      },
-      "EnumFromResults": {
-        "type": "object",
-        "properties": {
-          "query_id": {
-            "type": "integer",
-            "description": "The ID of the query to fetch results from."
-          },
-          "columnName": {
-            "type": "string",
-            "description": "The column name to use from the query results."
-          }
-        }
+        "example": {
+            "parameterNameFoo": "value of parameterNameFoo",
+            "parameterNameBar": 420
+        },
+        "description": "SQL Query parameters in key-value pairs. Each parameter is to be provided in key-value pairs. This enables you to execute a parameterized query with the provided values for your parameter keys. Partial submission of parameters is allowed. For example, if the query expects three parameters and you only pass in two, the third one will automatically use its default value as defined in the Query Parameter Editor page."
       },
       "Performance": {
         "type": "string",

--- a/api-reference/query-api/query-openapi.json
+++ b/api-reference/query-api/query-openapi.json
@@ -21,7 +21,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "API Key for accessing this service",
+            "description": "API Key for the service",
             "required": true
           },
           {
@@ -30,7 +30,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "API Key for accessing this service, alternative to using the HTTP header X-DUNE-API-KEY.",
+            "description": "API Key for the service, alternative to using the HTTP header X-DUNE-API-KEY.",
             "required": false
           },
           {
@@ -55,7 +55,7 @@
           },
           {
             "in": "query",
-            "name": "parameters",
+            "name": "query_parameters",
             "required": false,
             "explode": true,
             "schema": {
@@ -150,7 +150,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "API Key for accessing this service",
+            "description": "API Key for the service",
             "required": true
           },
           {
@@ -159,7 +159,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "API Key for accessing this service, alternative to using the HTTP header X-DUNE-API-KEY.",
+            "description": "API Key for the service, alternative to using the HTTP header X-DUNE-API-KEY.",
             "required": false
           },
           {
@@ -245,7 +245,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "API Key for accessing this service",
+            "description": "API Key for the service",
             "required": true
           },
           {
@@ -254,7 +254,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "API Key for accessing this service, alternative to using the HTTP header X-DUNE-API-KEY.",
+            "description": "API Key for the service, alternative to using the HTTP header X-DUNE-API-KEY.",
             "required": false
           },
           {
@@ -331,7 +331,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "API Key for accessing this service",
+            "description": "API Key for the service",
             "required": true
           },
           {
@@ -340,7 +340,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "API Key for accessing this service, alternative to using the HTTP header X-DUNE-API-KEY.",
+            "description": "API Key for the service, alternative to using the HTTP header X-DUNE-API-KEY.",
             "required": false
           },
           {
@@ -372,7 +372,7 @@
           },
           {
             "in": "query",
-            "name": "parameters",
+            "name": "query_parameters",
             "required": false,
             "explode": true,
             "schema": {
@@ -479,7 +479,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "API Key for accessing this service",
+            "description": "API Key for the service",
             "required": true
           },
           {
@@ -488,7 +488,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "API Key for accessing this service, alternative to using the HTTP header X-DUNE-API-KEY.",
+            "description": "API Key for the service, alternative to using the HTTP header X-DUNE-API-KEY.",
             "required": false
           },
           {
@@ -641,7 +641,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "API Key for accessing this service",
+            "description": "API Key for the service",
             "required": true
           },
           {
@@ -650,7 +650,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "API Key for accessing this service, alternative to using the HTTP header X-DUNE-API-KEY.",
+            "description": "API Key for the service, alternative to using the HTTP header X-DUNE-API-KEY.",
             "required": false
           },
           {
@@ -769,7 +769,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "API Key for accessing this service",
+            "description": "API Key for the service",
             "required": true
           },
           {
@@ -778,7 +778,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "API Key for accessing this service, alternative to using the HTTP header X-DUNE-API-KEY.",
+            "description": "API Key for the service, alternative to using the HTTP header X-DUNE-API-KEY.",
             "required": false
           },
           {

--- a/api-reference/query-api/query-openapi.json
+++ b/api-reference/query-api/query-openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.1",
   "info": {
     "title": "OpenAPI for Query and Execution API",
-    "description": "API for Querying and Executing Dune Data",
+    "description": "API for Querying and Reading Dune Data",
     "version": "1.0.0"
   },
   "servers": [
@@ -26,12 +26,32 @@
           },
           {
             "in": "path",
+            "name": "api_key",
+            "schema": {
+              "type": "string"
+            },
+            "description": "API Key for accessing this service, alternative to using the HTTP header X-DUNE-API-KEY.",
+            "required": false
+          },
+          {
+            "in": "path",
             "name": "query_id",
             "required": true,
             "schema": {
               "type": "integer"
             },
             "description": "unique identifier of the query"
+          },
+          {
+            "in": "query",
+            "name": "performance",
+            "required": false,
+            "schema": {
+              "items": {
+                "$ref": "#/components/schemas/Performance"
+              }
+            },
+            "description": "The performance engine tier the execution will be run on. Can be either medium or large. Medium consumes 10 credits, and large consumes 20 credits, per run. Default is medium."
           },
           {
             "in": "query",
@@ -43,18 +63,7 @@
                 "$ref": "#/components/schemas/ParameterObject"
               }
             },
-            "description": "Query parameters in key-value pairs. Each parameter is an object consisting of keys such as 'key', 'type', 'value', and optionally 'enumOptions'. The API allows for partial submission of parameters. For example, if the query expects three parameters and you only pass in two, the third one will automatically use its default value as defined in the API. This feature enables you to customize the query execution according to your specific needs while providing sensible defaults for unspecified parameters."
-          },
-          {
-            "in": "query",
-            "name": "performance",
-            "required": false,
-            "schema": {
-              "items": {
-                "$ref": "#/components/schemas/Performance"
-              }
-            },
-            "description": "Defines the engine the execution will be run on. Can be either medium or large tier. Medium consumes 10 credits per run and large consumes 20 credits per run. By default performance is medium."
+            "description": "SQL Query parameters in key-value pairs. Each parameter is an object consisting of keys such as 'key', 'type', 'value', and optionally 'enumOptions'. The API allows for partial submission of parameters. For example, if the query expects three parameters and you only pass in two, the third one will automatically use its default value as defined in the API. This feature enables you to parameterize the query execution according to your specific needs while providing sensible defaults for unspecified parameters."
           }
         ],
         "responses": {
@@ -73,7 +82,7 @@
             }
           },
           "400": {
-            "description": "Bad Request - The request could not be understood by the server due to malformed syntax or validation failure.",
+            "description": "Bad Request - The request could not be processed by the server due to malformed syntax or validation failure.",
             "content": {
               "application/json": {
                 "schema": {
@@ -113,13 +122,13 @@
                   "type": "object"
                 },
                 "example": {
-                  "error": "Not allowed to execute query. Query is archived or an unsaved query"
+                  "error": "Not allowed to execute query. Query is archived, unsaved or not enough permissions."
                 }
               }
             }
           },
           "500": {
-            "description": "Internal server error occurred. This usually happens due to unexpected issues in processing the request. It may include errors such as failure in core API execution, invalid query parameters, or issues with the customer data provided.",
+            "description": "Internal server error occurred. This usually happens due to unexpected issues in processing the request.",
             "content": {
               "application/json": {
                 "schema": {
@@ -143,6 +152,15 @@
             },
             "description": "API Key for accessing this service",
             "required": true
+          },
+          {
+            "in": "path",
+            "name": "api_key",
+            "schema": {
+              "type": "string"
+            },
+            "description": "API Key for accessing this service, alternative to using the HTTP header X-DUNE-API-KEY.",
+            "required": false
           },
           {
             "in": "path",
@@ -205,7 +223,7 @@
             }
           },
           "500": {
-            "description": "Internal server error occurred. This usually happens due to unexpected issues in processing the request. It may include errors such as failure in core API execution, invalid query parameters, or issues with the customer data provided.",
+            "description": "Internal server error occurred. This usually happens due to unexpected issues in processing the request.",
             "content": {
               "application/json": {
                 "schema": {
@@ -229,6 +247,15 @@
             },
             "description": "API Key for accessing this service",
             "required": true
+          },
+          {
+            "in": "path",
+            "name": "api_key",
+            "schema": {
+              "type": "string"
+            },
+            "description": "API Key for accessing this service, alternative to using the HTTP header X-DUNE-API-KEY.",
+            "required": false
           },
           {
             "in": "path",
@@ -282,7 +309,7 @@
             }
           },
           "500": {
-            "description": "Internal server error occurred. This usually happens due to unexpected issues in processing the request. It may include errors such as failure in core API execution, invalid query parameters, or issues with the customer data provided.",
+            "description": "Internal server error occurred. This usually happens due to unexpected issues in processing the request.",
             "content": {
               "application/json": {
                 "schema": {
@@ -306,6 +333,15 @@
             },
             "description": "API Key for accessing this service",
             "required": true
+          },
+          {
+            "in": "path",
+            "name": "api_key",
+            "schema": {
+              "type": "string"
+            },
+            "description": "API Key for accessing this service, alternative to using the HTTP header X-DUNE-API-KEY.",
+            "required": false
           },
           {
             "in": "path",
@@ -344,7 +380,7 @@
                 "$ref": "#/components/schemas/ParameterObject"
               }
             },
-            "description": "Query parameters in key-value pairs. Each parameter is an object consisting of keys such as 'key', 'type', 'value', and optionally 'enumOptions'. The API allows for partial submission of parameters. For example, if the query expects three parameters and you only pass in two, the third one will automatically use its default value as defined in the API. This feature enables you to customize the query execution according to your specific needs while providing sensible defaults for unspecified parameters."
+            "description": "SQL Query parameters in key-value pairs. Each parameter is an object consisting of keys such as 'key', 'type', 'value', and optionally 'enumOptions'. The API allows for partial submission of parameters. For example, if the query expects three parameters and you only pass in two, the third one will automatically use its default value as defined in the API. This feature enables you to parameterize the query execution according to your specific needs while providing sensible defaults for unspecified parameters."
           },
           {
             "in": "query",
@@ -362,7 +398,7 @@
             "schema": {
               "type": "boolean"
             },
-            "description": "Sometimes request results can be too large to return. By default allow_partial_results is set to false and a failed state is returned."
+            "description": "This enables returning a query result that was too large and only a partial result is available. By default allow_partial_results is set to false and a failed state is returned."
           }
         ],
         "responses": {
@@ -448,6 +484,15 @@
           },
           {
             "in": "path",
+            "name": "api_key",
+            "schema": {
+              "type": "string"
+            },
+            "description": "API Key for accessing this service, alternative to using the HTTP header X-DUNE-API-KEY.",
+            "required": false
+          },
+          {
+            "in": "path",
             "name": "query_id",
             "required": true,
             "schema": {
@@ -483,7 +528,7 @@
                 "$ref": "#/components/schemas/ParameterObject"
               }
             },
-            "description": "Query parameters in key-value pairs. Each parameter is an object consisting of keys such as 'key', 'type', 'value', and optionally 'enumOptions'. The API allows for partial submission of parameters. For example, if the query expects three parameters and you only pass in two, the third one will automatically use its default value as defined in the API. This feature enables you to customize the query execution according to your specific needs while providing sensible defaults for unspecified parameters."
+            "description": "SQL Query parameters in key-value pairs. Each parameter is an object consisting of keys such as 'key', 'type', 'value', and optionally 'enumOptions'. The API allows for partial submission of parameters. For example, if the query expects three parameters and you only pass in two, the third one will automatically use its default value as defined in the API. This feature enables you to parameterize the query execution according to your specific needs while providing sensible defaults for unspecified parameters."
           },
           {
             "in": "query",
@@ -501,7 +546,7 @@
             "schema": {
               "type": "boolean"
             },
-            "description": "Sometimes request results can be too large to return. By default allow_partial_results is set to false and a failed state is returned. "
+            "description": "This enables returning a query result that was too large and only a partial result is available. By default allow_partial_results is set to false and a failed state is returned."
           }
         ],
         "responses": {
@@ -601,6 +646,15 @@
           },
           {
             "in": "path",
+            "name": "api_key",
+            "schema": {
+              "type": "string"
+            },
+            "description": "API Key for accessing this service, alternative to using the HTTP header X-DUNE-API-KEY.",
+            "required": false
+          },
+          {
+            "in": "path",
             "name": "execution_id",
             "required": true,
             "schema": {
@@ -642,7 +696,7 @@
             "schema": {
               "type": "boolean"
             },
-            "description": "Sometimes request results can be too large to return. By default allow_partial_results is set to false and a failed state is returned. "
+            "description": "This enables returning a query result that was too large and only a partial result is available. By default allow_partial_results is set to false and a failed state is returned."
           }
         ],
         "responses": {
@@ -720,6 +774,15 @@
           },
           {
             "in": "path",
+            "name": "api_key",
+            "schema": {
+              "type": "string"
+            },
+            "description": "API Key for accessing this service, alternative to using the HTTP header X-DUNE-API-KEY.",
+            "required": false
+          },
+          {
+            "in": "path",
             "name": "execution_id",
             "required": true,
             "schema": {
@@ -761,7 +824,7 @@
             "schema": {
               "type": "boolean"
             },
-            "description": "Sometimes request results can be too large to return. By default allow_partial_results is set to false and a failed state is returned. "
+            "description": "This enables returning a query result that was too large and only a partial result is available. By default allow_partial_results is set to false and a failed state is returned."
           }
         ],
         "responses": {
@@ -834,7 +897,7 @@
                   "type": "object"
                 },
                 "example": {
-                  "error": "Query state is not QUERY_STATE_CANCELLED, cannot provide CSV Result",
+                  "error": "Query state is not QUERY_STATE_COMPLETED, cannot provide CSV Result",
                   "errorDetails": null,
                   "state": "QUERY_STATE_CANCELLED"
                 }
@@ -1025,7 +1088,7 @@
         "properties": {
           "execution_id": {
             "type": "string",
-            "description": "Unique identifier for the execution of the query.",
+            "description": "Unique identifier for the execution of the query and corresponding result.",
             "example": "01HKZSJAW6N2MFVCBHA3R8S64X"
           },
           "query_id": {
@@ -1085,7 +1148,7 @@
             "$ref": "#/components/schemas/ExecutionResultMetadata"
           },
           "rows": {
-            "$ref": "#/components/schemas/QueryResultRow"
+            "$ref": "#/components/schemas/QueryResultRows"
           }
         }
       },
@@ -1105,9 +1168,9 @@
           }
         }
       },
-      "QueryResultRow": {
+      "QueryResultRows": {
         "type": "object",
-        "description": "A row is dictionary of key-value pairs returned by the query, each pair corresponding to a column",
+        "description": "A list of rows. A row is dictionary of key-value pairs returned by the query, each pair corresponding to a column",
         "example": [
           {
             "24 Hours Volume": 8466988.095521685,
@@ -1223,7 +1286,7 @@
           },
           "total_result_set_bytes": {
             "type": "integer",
-            "description": "Total number of bytes in the result set.",
+            "description": "Total number of bytes in the result set. This doesn't include the json representation overhead.",
             "example": 1541
           },
           "total_row_count": {
@@ -1251,6 +1314,7 @@
       "ParameterObject": {
         "type": "object",
         "required": ["key"],
+        "description": "SQL Query parameters in key-value pairs. Each parameter is an object consisting of keys such as 'key', 'type', 'value', and optionally 'enumOptions'. The API allows for partial submission of parameters. For example, if the query expects three parameters and you only pass in two, the third one will automatically use its default value as defined in the API. This feature enables you to parameterize the query execution according to your specific needs while providing sensible defaults for unspecified parameters.",
         "properties": {
           "key": {
             "type": "string",
@@ -1312,7 +1376,7 @@
       "Performance": {
         "type": "string",
         "enum": ["medium", "large"],
-        "description": "Defines the engine the execution will be run on. Can be either medium or large tier. Medium consumes 10 credits per run, and large consumes 20 credits per run. By default, performance is medium."
+        "description": "The performance engine tier the execution will be run on. Can be either medium or large. Medium consumes 10 credits, and large consumes 20 credits, per run. Default is medium."
       },
       "UnauthorizedError": {
         "type": "object",

--- a/api-reference/query-api/query-openapi.json
+++ b/api-reference/query-api/query-openapi.json
@@ -25,7 +25,7 @@
             "required": true
           },
           {
-            "in": "path",
+            "in": "query",
             "name": "api_key",
             "schema": {
               "type": "string"
@@ -154,7 +154,7 @@
             "required": true
           },
           {
-            "in": "path",
+            "in": "query",
             "name": "api_key",
             "schema": {
               "type": "string"
@@ -249,7 +249,7 @@
             "required": true
           },
           {
-            "in": "path",
+            "in": "query",
             "name": "api_key",
             "schema": {
               "type": "string"
@@ -335,7 +335,7 @@
             "required": true
           },
           {
-            "in": "path",
+            "in": "query",
             "name": "api_key",
             "schema": {
               "type": "string"
@@ -483,7 +483,7 @@
             "required": true
           },
           {
-            "in": "path",
+            "in": "query",
             "name": "api_key",
             "schema": {
               "type": "string"
@@ -645,7 +645,7 @@
             "required": true
           },
           {
-            "in": "path",
+            "in": "query",
             "name": "api_key",
             "schema": {
               "type": "string"
@@ -773,7 +773,7 @@
             "required": true
           },
           {
-            "in": "path",
+            "in": "query",
             "name": "api_key",
             "schema": {
               "type": "string"

--- a/api-reference/upload/upload-openapi.json
+++ b/api-reference/upload/upload-openapi.json
@@ -23,8 +23,17 @@
             "schema": {
               "type": "string"
             },
-            "description": "API Key for accessing this service",
+            "description": "API Key for the service",
             "required": true
+          },
+          {
+            "in": "path",
+            "name": "api_key",
+            "schema": {
+              "type": "string"
+            },
+            "description": "API Key for the service, alternative to using the HTTP header X-DUNE-API-KEY.",
+            "required": false
           }
         ],
         "requestBody": {

--- a/api-reference/upload/upload-openapi.json
+++ b/api-reference/upload/upload-openapi.json
@@ -27,7 +27,7 @@
             "required": true
           },
           {
-            "in": "path",
+            "in": "query",
             "name": "api_key",
             "schema": {
               "type": "string"


### PR DESCRIPTION
- wording on multiple descriptions was cleaned up.
- adding api_key query parameter
- Improved documentation on the Pagination page