### PR TITLE
add ts SDK example for executing and fetching query results in one call

### DIFF
--- a/api-reference/executions/endpoint/get-execution-result.mdx
+++ b/api-reference/executions/endpoint/get-execution-result.mdx
@@ -16,7 +16,7 @@ Result returns the status, metadata, and query results (in JSON) from a query ex
 </Info>
 
 <Accordion title="Execute query and get result in one call">
-  <Tip> If you are using the [Python SDK](https://github.com/duneanalytics/dune-client/tree/d2195b2a9577e2dcae5d2600cb3eddce20987f38) or community [Typescript SDK](https://github.com/bh2smith/ts-dune-client), you can directly executes and fetches result in one function call, like below: </Tip>
+  <Tip> If you are using the [Python SDK](https://github.com/duneanalytics/dune-client/tree/d2195b2a9577e2dcae5d2600cb3eddce20987f38) or community [Typescript SDK](https://github.com/bh2smith/ts-dune-client), you can directly execute and fetch a result in one function call, like below: </Tip>
 
   <Tabs>
     <Tab title="Python SDK">

--- a/api-reference/executions/endpoint/get-execution-result.mdx
+++ b/api-reference/executions/endpoint/get-execution-result.mdx
@@ -18,7 +18,9 @@ Result returns the status, metadata, and query results (in JSON) from a query ex
 <Accordion title="Execute query and get result in one call">
   <Tip> If you are using the [Python SDK](https://github.com/duneanalytics/dune-client/tree/d2195b2a9577e2dcae5d2600cb3eddce20987f38), you can directly executes and fetches result in one function call, like below: </Tip>
 
-    ``` python Python SDK 
+  <Tabs>
+    <Tab title="Python SDK">
+    ``` python
 
     import dotenv, os, json
     from dune_client.types import QueryParameter
@@ -44,6 +46,43 @@ Result returns the status, metadata, and query results (in JSON) from a query ex
         )
 
     ```
+    </Tab>
+
+    <Tab title="Typescript SDK">
+      ``` typescript
+      import { QueryParameter, DuneClient } from "@cowprotocol/ts-dune-client";
+      const { DUNE_API_KEY } = process.env;
+      const client = new DuneClient(DUNE_API_KEY ?? "");
+      ```
+
+      Use `refresh` to get result in JSON
+
+      ``` typescript
+      const queryID = 1215383;
+      const parameters = [
+        QueryParameter.text("TextField", "Plain Text"),
+        QueryParameter.number("NumberField", 3.1415926535),
+        QueryParameter.date("DateField", "2022-05-04 00:00:00"),
+        QueryParameter.enum("ListField", "Option 1"),
+      ];
+
+      client
+        .refresh(queryID, parameters)
+        .then((executionResult) => console.log(executionResult.result?.rows));
+
+      // should look like
+      // [
+      //   {
+      //     date_field: "2022-05-04 00:00:00",
+      //     list_field: "Option 1",
+      //     number_field: "3.1415926535",
+      //     text_field: "Plain Text",
+      //   },
+      // ];
+      ```
+    </Tab>
+
+  </Tabs>
 </Accordion>
 
 <RequestExample>

--- a/api-reference/executions/endpoint/get-execution-result.mdx
+++ b/api-reference/executions/endpoint/get-execution-result.mdx
@@ -16,7 +16,7 @@ Result returns the status, metadata, and query results (in JSON) from a query ex
 </Info>
 
 <Accordion title="Execute query and get result in one call">
-  <Tip> If you are using the [Python SDK](https://github.com/duneanalytics/dune-client/tree/d2195b2a9577e2dcae5d2600cb3eddce20987f38) or [TypeScript SDK](https://github.com/bh2smith/demo-ts-dune-client), you can directly executes and fetches result in one function call, like below: </Tip>
+  <Tip> If you are using the [Python SDK](https://github.com/duneanalytics/dune-client/tree/d2195b2a9577e2dcae5d2600cb3eddce20987f38) or community [Typescript SDK](https://github.com/bh2smith/ts-dune-client), you can directly executes and fetches result in one function call, like below: </Tip>
 
   <Tabs>
     <Tab title="Python SDK">

--- a/api-reference/executions/endpoint/get-execution-result.mdx
+++ b/api-reference/executions/endpoint/get-execution-result.mdx
@@ -16,7 +16,7 @@ Result returns the status, metadata, and query results (in JSON) from a query ex
 </Info>
 
 <Accordion title="Execute query and get result in one call">
-  <Tip> If you are using the [Python SDK](https://github.com/duneanalytics/dune-client/tree/d2195b2a9577e2dcae5d2600cb3eddce20987f38), you can directly executes and fetches result in one function call, like below: </Tip>
+  <Tip> If you are using the [Python SDK](https://github.com/duneanalytics/dune-client/tree/d2195b2a9577e2dcae5d2600cb3eddce20987f38) or [TypeScript SDK](https://github.com/bh2smith/demo-ts-dune-client), you can directly executes and fetches result in one function call, like below: </Tip>
 
   <Tabs>
     <Tab title="Python SDK">


### PR DESCRIPTION
- add community ts sdk snippet of getting query execution result

before:
<img width="899" alt="image" src="https://github.com/duneanalytics/dune-api-docs/assets/38522988/906f7de9-e098-4a9d-8370-6be2e45270ad">

after:
<img width="956" alt="image" src="https://github.com/duneanalytics/dune-api-docs/assets/38522988/d3114a7f-f42e-4aec-8681-86f80efcb12f">

