### PR TITLE
PRO-968: Document ss58 encoding / decoding scheme

### DIFF
--- a/mint.json
+++ b/mint.json
@@ -142,6 +142,7 @@
             "query-engine/Functions-and-operators/qdigest",
             "query-engine/Functions-and-operators/regexp",
             "query-engine/Functions-and-operators/setdigest",
+            "query-engine/Functions-and-operators/ss58",
             "query-engine/Functions-and-operators/string",
             "query-engine/Functions-and-operators/system",
             "query-engine/Functions-and-operators/tdigest",

--- a/query-engine/Functions-and-operators/index.mdx
+++ b/query-engine/Functions-and-operators/index.mdx
@@ -10,6 +10,7 @@ Using ``SHOW FUNCTIONS`` in the query editor returns a list of all available fun
 ### DuneSQL Added Functions:
 - [Varbinary datatypes](/query-engine/Functions-and-operators/varbinary)
 - [Base58](/query-engine/Functions-and-operators/base58)
+- [ss58](/query-engine/Functions-and-operators/ss58)
 - [Chain Utility Functions](/query-engine/Functions-and-operators/chain-utility-functions)
 - [Varchar Utility Functions](/query-engine/Functions-and-operators/varchar-utility-functions)
 ### Trino Base Functions:

--- a/query-engine/Functions-and-operators/ss58.mdx
+++ b/query-engine/Functions-and-operators/ss58.mdx
@@ -1,0 +1,37 @@
+---
+title: SS58 functions
+---
+
+ss58 or substrate58 is an address encoding scheme that is commonly used in substrate-based chains. It is similar to [Base58](/query-engine/Functions-and-operators/base58) encoding format, with some modifications.
+
+Under basic ss58 encoding format an address can be encoded as:
+```
+base58encode ( concat ( <address-type>, <address>, <checksum> ) )
+```
+
+## Functions
+
+#### from_ss58()
+**`from_ss58(varchar)`** → `varbinary`
+
+Converts an ss58-encoded string to the corresponding `VARBINARY` address.
+
+```sql
+SELECT 
+    from_ss58('1qnJN7FViy3HZaxZK9tGAA71zxHSBeUweirKqCaox4t8GT7')
+-- results in VARBINARY 0x2534454d30f8a028e42654d6b535e0651d1d026ddf115cef59ae1dd71bae074e
+```
+
+#### to_ss58()
+**`to_ss58(varbinary, int)`** → `varchar`
+
+Encodes an address of a specific network type into its ss58 `VARCHAR` representation. For example:
+    * `Polkadot` has address type 0
+    * `Kusama` has address type 2
+    * `Generic Substrate` has address type 42
+
+```sql
+SELECT 
+    to_ss58('0x2534454d30f8a028e42654d6b535e0651d1d026ddf115cef59ae1dd71bae074e', 2)
+-- results 'DR6pMC4GJiVbgPtNNuw1xgxJyEsYYuXKXq7ZCVBjfFrh3V5'
+```


### PR DESCRIPTION
Document ss58 encoding / decoding scheme. Information taken from [here](https://wiki.polkadot.network/docs/learn-account-advanced) and [here](https://docs.substrate.io/reference/address-formats/)
![Screenshot 2024-03-13 at 5 21 47 PM](https://github.com/duneanalytics/dune-api-docs/assets/7823083/075ac480-f978-4513-9419-cd61a571a3c8)
