### PR TITLE
Pro 1052 add table endpoint documentation in SDK, Python, and Javascript

### DIFF
--- a/api-reference/tables/endpoint/create.mdx
+++ b/api-reference/tables/endpoint/create.mdx
@@ -20,14 +20,83 @@ The resulting table will be empty, and can be inserted into with the [/insert en
 
 ```bash curl
 curl --request POST \
-  --url https://api.dune.com/api/v1/table/my_user/dataset_interest_rates/create \
+  --url https://api.dune.com/api/v1/table/create \
   --header 'X-DUNE-API-KEY: <x-dune-api-key>' \
   --header 'Content-Type: application/json' \
   --data '{
+  "namespace":"my_user",
+  "table_name":"dataset_interest_rates",
   "description": "10 year daily interest rates, sourced from https://fred.stlouisfed.org/series/DGS10",
   "is_private": false,
   "schema": [{"name": "date", "type": "timestamp"}, {"name": "dgs10", "type": "double"}]
 }'
 ```
 
+```python Python SDK
+import dotenv, os
+from dune_client.client import DuneClient
+ 
+dotenv_path = os.path.join(os.path.dirname(__file__), '.', '.env')
+dotenv.load_dotenv(".env")
+dune = DuneClient.from_env()
+
+table = DuneClient.from_env().create_table(
+        namespace="my_user",
+        table_name="dataset_interest_rates",
+        description="10 year daily interest rates, sourced from https://fred.stlouisfed.org/series/DGS10",
+        schema= [
+            {"name": "date", "type": "timestamp"},
+            {"name": "dgs10", "type": "double"}
+        ],
+        is_private=False
+)
+```
+
+```python Python
+import requests
+
+url = "https://api.dune.com/api/v1/table/create"
+
+payload = {
+    "namespace": "my_user",
+    "table_name": "dataset_interest_rates",
+    "description": "10 year daily interest rates, sourced from https://fred.stlouisfed.org/series/DGS10",
+    "schema": [{"name": "date", "type": "timestamp"}, {"name": "dgs10", "type": "double"}],
+    "is_private": False
+}
+
+headers = {
+    "X-DUNE-API-KEY": "<x-dune-api-key>",
+    "Content-Type": "application/json"
+}
+
+
+response = requests.request("POST", url, json=payload, headers=headers)
+```
+
+```javascript Javascript
+const url = "https://api.dune.com/api/v1/table/create";
+
+const payload = {
+    "namespace": "my_user",
+    "table_name": "dataset_interest_rates",
+    "description": "10 year daily interest rates, sourced from https://fred.stlouisfed.org/series/DGS10",
+    "schema": [{"name": "date", "type": "timestamp"}, {"name": "dgs10", "type": "double"}],
+    "is_private": false
+};
+
+const headers = {
+    "X-DUNE-API-KEY": "<x-dune-api-key>",
+    "Content-Type": "text/csv"
+};
+
+fetch(url, {
+    method: 'POST',
+    headers: headers,
+    body: JSON.stringify(payload)
+})
+.then(response => response.json())
+.then(response => console.log(response))
+.catch(err => console.error(err));
+```
 </RequestExample>

--- a/api-reference/tables/endpoint/create.mdx
+++ b/api-reference/tables/endpoint/create.mdx
@@ -25,7 +25,7 @@ curl --request POST \
   --header 'Content-Type: application/json' \
   --data '{
   "namespace":"my_user",
-  "table_name":"dataset_interest_rates",
+  "table_name":"interest_rates",
   "description": "10 year daily interest rates, sourced from https://fred.stlouisfed.org/series/DGS10",
   "is_private": false,
   "schema": [{"name": "date", "type": "timestamp"}, {"name": "dgs10", "type": "double"}]
@@ -40,9 +40,9 @@ dotenv_path = os.path.join(os.path.dirname(__file__), '.', '.env')
 dotenv.load_dotenv(".env")
 dune = DuneClient.from_env()
 
-table = DuneClient.from_env().create_table(
+table = dune.create_table(
         namespace="my_user",
-        table_name="dataset_interest_rates",
+        table_name="interest_rates",
         description="10 year daily interest rates, sourced from https://fred.stlouisfed.org/series/DGS10",
         schema= [
             {"name": "date", "type": "timestamp"},
@@ -59,7 +59,7 @@ url = "https://api.dune.com/api/v1/table/create"
 
 payload = {
     "namespace": "my_user",
-    "table_name": "dataset_interest_rates",
+    "table_name": "interest_rates",
     "description": "10 year daily interest rates, sourced from https://fred.stlouisfed.org/series/DGS10",
     "schema": [{"name": "date", "type": "timestamp"}, {"name": "dgs10", "type": "double"}],
     "is_private": False
@@ -79,7 +79,7 @@ const url = "https://api.dune.com/api/v1/table/create";
 
 const payload = {
     "namespace": "my_user",
-    "table_name": "dataset_interest_rates",
+    "table_name": "interest_rates",
     "description": "10 year daily interest rates, sourced from https://fred.stlouisfed.org/series/DGS10",
     "schema": [{"name": "date", "type": "timestamp"}, {"name": "dgs10", "type": "double"}],
     "is_private": false
@@ -87,7 +87,7 @@ const payload = {
 
 const headers = {
     "X-DUNE-API-KEY": "<x-dune-api-key>",
-    "Content-Type": "text/csv"
+    "Content-Type": "application/json"
 };
 
 fetch(url, {

--- a/api-reference/tables/endpoint/insert.mdx
+++ b/api-reference/tables/endpoint/insert.mdx
@@ -25,7 +25,7 @@ Each line must have keys that match the column names of the table.
 <RequestExample>
 ```bash curl
 curl --request POST \
-  --url https://api.dune.com/api/v1/table/my_user/dataset_interest_rates/insert \
+  --url https://api.dune.com/api/v1/table/my_user/interest_rates/insert \
   --header 'X-DUNE-API-KEY: <x-dune-api-key>' \
   --header 'Content-Type: text/csv' \
   --upload-file interest_rates.csv
@@ -42,7 +42,7 @@ dune = DuneClient.from_env()
 with open("./interest_rates.csv", "rb") as data:
     response = dune.insert_table(
             namespace="my_user",
-            table_name="dataset_interest_rates",
+            table_name="interest_rates",
             data=data,
             content_type="text/csv"
         )
@@ -51,7 +51,7 @@ with open("./interest_rates.csv", "rb") as data:
 ```python Python
 import requests
 
-url = "https://api.dune.com/api/v1/table/my_user/dataset_interest_rates/insert"
+url = "https://api.dune.com/api/v1/table/my_user/interest_rates/insert"
 
 headers = {
     "X-DUNE-API-KEY": "<x-dune-api-key>",
@@ -64,7 +64,7 @@ with open("./interest_rates.csv", "rb") as data:
 
 
 ```javascript Javascript
-const url = "https://api.dune.com/api/v1/table/my_user/dataset_interest_rates/insert";
+const url = "https://api.dune.com/api/v1/table/my_user/interest_rates/insert";
 
 const headers = {
     "X-DUNE-API-KEY": "<x-dune-api-key>",

--- a/api-reference/tables/endpoint/insert.mdx
+++ b/api-reference/tables/endpoint/insert.mdx
@@ -30,4 +30,61 @@ curl --request POST \
   --header 'Content-Type: text/csv' \
   --upload-file interest_rates.csv
 ```
+
+```python Python SDK
+import dotenv, os
+from dune_client.client import DuneClient
+ 
+dotenv_path = os.path.join(os.path.dirname(__file__), '.', '.env')
+dotenv.load_dotenv(".env")
+dune = DuneClient.from_env()
+
+with open("./interest_rates.csv", "rb") as data:
+    response = dune.insert_table(
+            namespace="my_user",
+            table_name="dataset_interest_rates",
+            data=data,
+            content_type="text/csv"
+        )
+```
+
+```python Python
+import requests
+
+url = "https://api.dune.com/api/v1/table/my_user/dataset_interest_rates/insert"
+
+headers = {
+    "X-DUNE-API-KEY": "<x-dune-api-key>",
+    "Content-Type": "text/csv"
+}
+
+with open("./interest_rates.csv", "rb") as data:
+  response = requests.request("POST", url, data=data, headers=headers)
+```
+
+
+```javascript Javascript
+const url = "https://api.dune.com/api/v1/table/my_user/dataset_interest_rates/insert";
+
+const headers = {
+    "X-DUNE-API-KEY": "<x-dune-api-key>",
+    "Content-Type": "text/csv"
+};
+
+fs.readFile('./interest_rates.csv', (err, data) => {
+  if (err) {
+      console.error(err);
+      return;
+  }
+
+  fetch(url, {
+        method: 'POST',
+        headers: headers,
+        body: data
+    })  
+    .then(response => response.json())
+    .then(response => console.log(response))
+    .catch(err => console.error(err));
+});
+```
 </RequestExample>


### PR DESCRIPTION
We are adding documentation to the `/create` and `/insert` table endpoints