### PR TITLE
Add Tron address functions to Query Engine docs

### DIFF
--- a/mint.json
+++ b/mint.json
@@ -152,6 +152,7 @@
             "query-engine/Functions-and-operators/regexp",
             "query-engine/Functions-and-operators/setdigest",
             "query-engine/Functions-and-operators/ss58",
+            "query-engine/Functions-and-operators/tronaddress",
             "query-engine/Functions-and-operators/string",
             "query-engine/Functions-and-operators/system",
             "query-engine/Functions-and-operators/tdigest",

--- a/query-engine/Functions-and-operators/index.mdx
+++ b/query-engine/Functions-and-operators/index.mdx
@@ -12,6 +12,7 @@ Using ``SHOW FUNCTIONS`` in the query editor returns a list of all available fun
 - [Varbinary datatypes](/query-engine/Functions-and-operators/varbinary)
 - [Base58](/query-engine/Functions-and-operators/base58)
 - [ss58](/query-engine/Functions-and-operators/ss58)
+- [Tron Address Functions](/query-engine/Functions-and-operators/tronaddress)
 - [Chain Utility Functions](/query-engine/Functions-and-operators/chain-utility-functions)
 - [Varchar Utility Functions](/query-engine/Functions-and-operators/varchar-utility-functions)
 ### Trino Base Functions:

--- a/query-engine/Functions-and-operators/tronaddress.mdx
+++ b/query-engine/Functions-and-operators/tronaddress.mdx
@@ -1,0 +1,34 @@
+---
+title: Tron address functions
+---
+
+Tron blockchain adopted a custom type of addresses. It is similar to [Base58](/query-engine/Functions-and-operators/base58) encoding format, with some modifications.
+
+Under basic tron address encoding format an address can be encoded as:
+```
+base58encode ( concat ( <constant-prefix>, <address>, <checksum> ) )
+```
+
+## Functions
+
+#### from_tron_address()
+**`from_tron_address(varchar)`** → `varbinary`
+
+Converts a Tron address string to the corresponding `VARBINARY` hex address.
+
+```sql
+SELECT 
+    from_tron_address('THHRK1bA7YRPZBcLnTP1SZy9ipUpsRwpo6')
+-- results in VARBINARY 0x503aa4ad108bd3a89ba0310e23b49fb654cd6986
+```
+
+#### to_tron_address()
+**`to_tron_address(varbinary)`** → `varchar`
+
+Encodes a `VARBINARY` hex address to the corresponding Tron address.
+
+```sql
+SELECT 
+    to_tron_address(0x503aa4ad108bd3a89ba0310e23b49fb654cd6986)
+-- results 'THHRK1bA7YRPZBcLnTP1SZy9ipUpsRwpo6'
+```


### PR DESCRIPTION
This PR adds `Tron` address functions to the Query Engine docs. `Tron` addresses have custom encoding. We provide Trino UDF functions to go from `hex` address format to tron address and the opposite.

Tron address format documentation can be found [here](https://github.com/tronprotocol/documentation/blob/master/TRX/Tron-overview.md#62-mainnet-addresses-begin-with-41).