### PR TITLE
Small fix in Tron docs

### DIFF
--- a/data-catalog/tron/raw/blocks.mdx
+++ b/data-catalog/tron/raw/blocks.mdx
@@ -38,7 +38,7 @@ ORDER BY
 LIMIT 10
 ```
 
-### Show the number of blocks mined each day
+### Show the number of blocks produced each day
 
 ```sql
 SELECT


### PR DESCRIPTION
Change `mined` to `produced`. Tron blocks are not mined