### PR TITLE
Adding servers config to tables documentation

### DIFF
--- a/api-reference/tables/tables-openapi.json
+++ b/api-reference/tables/tables-openapi.json
@@ -4,6 +4,11 @@
     "title": "Table endpoints",
     "version": "1.0.0"
   },
+  "servers": [
+    {
+      "url": "https://api.dune.com/api"
+    }
+  ],
   "paths": {
     "/v1/table/create": {
       "post": {


### PR DESCRIPTION
This resolves not being able to run `tables` endpoints in the docs