### PR TITLE
A Few Trivial Broken Links

### DIFF
--- a/api-reference/overview/rate-limits.mdx
+++ b/api-reference/overview/rate-limits.mdx
@@ -19,8 +19,8 @@ Our rate limits are implemented in three ways: IP, low vs. high limit endpoints 
     - [delete table](../tables/endpoint/delete)
 - High limit endpoints _(read-heavy operations)_
     - [read query](../queries/endpoint/read)
-    - [get execution result](../queries/endpoint/get-execution-result)
-    - [get execution result CSV](../queries/endpoint/get-execution-result-csv)
+    - [get execution result](../executions/endpoint/get-execution-result)
+    - [get execution result CSV](../executions/endpoint/get-execution-result-csv)
     - [get execution status](../executions/endpoint/get-execution-status)
     - [cancel execution](../executions/endpoint/cancel-execution)
 

--- a/data-catalog/evm/ethereum/decoded/overview.mdx
+++ b/data-catalog/evm/ethereum/decoded/overview.mdx
@@ -137,7 +137,7 @@ In this case, they map out like this:
 | topic2         | to                                             | 0x00000000000000000000000087d9da48db6e1f925cb67d3b7d2a292846c24cf7 | 0x87d9da48db6e1f925cb67d3b7d2a292846c24cf7                                    |
 | data           | value                                          | 0x00000000000000000000000000000000000000000000001a894d51f85cb08000 | 489509000000000000000                                                         |
 
-Now what works for a single erc20 token, works for all erc20 tokens. We can use defined interfaces to decode the data of any erc20 token transfer event log. You can learn more about that in the [ERC20 transfer section](/data-catalog/evm/ethereum/assets/transfers/erc20-transfers).
+Now what works for a single erc20 token, works for all erc20 tokens. We can use defined interfaces to decode the data of any erc20 token transfer event log. You can learn more about that in the [ERC20 transfer section](/data-catalog/evm/ethereum/tokens/transfers/erc20-transfers).
 
 ## How do I understand decoded data?
 

--- a/data-catalog/evm/polygon-zkEVM/overview.mdx
+++ b/data-catalog/evm/polygon-zkEVM/overview.mdx
@@ -22,16 +22,16 @@ Dune offers comprehensive datasets for Polygon zkEVM, including event logs, tran
 ## Data Catalog
 
 <CardGroup cols={2}>
-  <Card title="Logs" icon="bolt" href="/data-catalog/evm/polygon-zkevm/raw/logs">
+  <Card title="Logs" icon="bolt" href="./raw/logs">
     Event logs from smart contracts, providing insights into contract interactions
   </Card>
-  <Card title="Blocks" icon="cubes" href="/data-catalog/evm/polygon-zkevm/raw/blocks">
+  <Card title="Blocks" icon="cubes" href="./raw/blocks">
     Information and statistics on blocks, showcasing the network's activity and throughput
   </Card>
-  <Card title="Transactions" icon="message-arrow-up" href="/data-catalog/evm/polygon-zkevm/raw/transactions">
+  <Card title="Transactions" icon="message-arrow-up" href="./raw/transactions">
     Detailed transaction data, highlighting the execution and efficiency of operations
   </Card>
-  <Card title="decoded" icon="file" href="/data-catalog/evm/polygon-zkevm/decoded/overview">
+  <Card title="decoded" icon="file" href="./decoded/overview">
     Decoded transaction data for easier understanding and analysis of smart contract executions
   </Card>
 </CardGroup>

--- a/data-catalog/spellbook/index.mdx
+++ b/data-catalog/spellbook/index.mdx
@@ -27,7 +27,7 @@ Spellbook is an open-source [dbt repository](https://docs.getdbt.com/docs/introd
 
 **Spells are custom tables that are built and maintained by Dune and our community.**
 
-It enables the community to build toward a standardized way to transform data into meaningful abstraction layers. With web3 data, we have a foundational layer of [Raw Data](/data-catalog/evm/ethereum/raw/) - blockchain transactions, traces, and logs. Spellbook lets us create abstracted data sets, like [dex.trades](../data-catalog/evm/ethereum/DEX/dex-trades) and [nft.trades](/data-catalog/evm/ethereum/NFT/nft-trades), which aggregate and organize raw data from multiple sources to make it much easier to query.
+It enables the community to build toward a standardized way to transform data into meaningful abstraction layers. With web3 data, we have a foundational layer of [Raw Data](/data-catalog/evm/ethereum/raw/) - blockchain transactions, traces, and logs. Spellbook lets us create abstracted data sets, like [dex.trades](../evm/ethereum/DEX/dex-trades) and [nft.trades](/data-catalog/evm/ethereum/NFT/nft-trades), which aggregate and organize raw data from multiple sources to make it much easier to query.
 
 dbt natively understands the dependencies between all models. In our old abstractions logic we were managing dependencies manually, which made deploying and maintaining them a mess. With dependency management, we can guarantee that all models are deployed in the correct order.
 


### PR DESCRIPTION
When following the README and running `mintlify broken-links` (from main) there were 14 broken links.

This PR reduces that to 8. The remaining broken links are pointing to non-existent files or are self referential links that don't appear to make sense and will be less trivial to fix.

Note that most of the the remaining problems are with `spellbook/index.md`. First, there does not appear to be any link to this page in the project and this page references itself several times.

cc @agaperste 